### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # .github
 
+[![Project Status: Unsupported](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported)
+
+**This project is archived for future reference, but no new work is expected in this repository.**
+
 A repository for default files
 
 Default files will be used for any public repository in the organization
@@ -9,4 +13,3 @@ that does not contain its own file of that type.
 types](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization#supported-file-types).
 * [Creating new files](https://help.github.com/en/articles/creating-new-files).
 * [Creating a repository for default files](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization#creating-a-repository-for-default-files).
-


### PR DESCRIPTION
This PR marks the repository as archived in the README by adding the unsupported badge and archive notice under the main header.